### PR TITLE
Add a shell.nix

### DIFF
--- a/cabal.config
+++ b/cabal.config
@@ -1,0 +1,2 @@
+documentation: True
+-- library-profiling: True

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,35 @@
+with (import <nixpkgs> {}).pkgs;
+with (import <nixpkgs/pkgs/development/haskell-modules/lib.nix> { pkgs = import <nixpkgs> {}; });
+let
+    hsPkgs = haskellngPackages.override {
+      overrides = self: super: {
+        Rasterific = dontCheck (super.Rasterific);
+        readable = overrideCabal (super.readable.overrideScope (self: super: { }))(drv: {
+           version = "0.2.0.2";
+           sha256 = "0dv1xr4y5azcr8xnhsl7i8ab56mkq7b89x55c2rg9kfakmgxiqcl";
+           });
+      };
+    };
+    pkg = hsPkgs.callPackage
+            ({ mkDerivation, base, ghc-prim, pipes, readable, stdenv
+             , template-haskell, text, transformers, vector, vinyl
+             , cairo, diagrams, diagrams-rasterific, Chart, Chart-diagrams
+             , lens, lens-family, foldl, list-t, http-client, statistics, zip-archive
+             }:
+             mkDerivation {
+               pname = "Frames";
+               version = "0.1.0.0";
+               src = ./.;
+               isLibrary = true;
+               isExecutable = true;
+               buildDepends = [
+                 base ghc-prim pipes readable template-haskell text transformers
+                 vector vinyl
+                 cairo diagrams diagrams-rasterific Chart Chart-diagrams
+                 lens lens-family foldl list-t http-client statistics zip-archive
+               ];
+               description = "Data frames For working with tabular data files";
+               license = stdenv.lib.licenses.bsd3;
+             }) {};
+in
+  pkg.env


### PR DESCRIPTION
Add shell.nix and turn off profiling.

Works with current Nixos/master, including demos

Assuming you have a checkout of nixpkgs in `~/dev`:
```shell
⇒  nix-shell -I ~/dev/ --command "cabal configure -fdemos"
⇒  cabal run getdata
Preprocessing executable 'getdata' for Frames-0.1.0.0...
Running getdata...

⇒  cabal run plot2
Preprocessing library Frames-0.1.0.0...
In-place registering Frames-0.1.0.0...
Preprocessing executable 'plot2' for Frames-0.1.0.0...
[1 of 1] Compiling Main             ( demo/Plot2.hs, dist/build/plot2/plot2-tmp/Main.o )
Loading package ghc-prim ... linking ... done.
# ....
Linking dist/build/plot2/plot2 ...
Running plot2...
The average farmer/fisher is 48.47222222222222 and made 8141.5

```