### PR TITLE
Minor update to Demos section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ executables associated with each demo.
 ```
 $ cabal sandbox init
 $ cabal install --dependencies-only -f demos
+$ cabal configure -f demos
 $ cabal run getdata
 $ cabal run plot
 ```


### PR DESCRIPTION
Without the `configure` step I got the following error:

```
$ cabal run getdata
Package has never been configured. Configuring with default flags. If this
fails, please run configure manually.
Resolving dependencies...
Configuring Frames-0.1.0.0...
cabal: Cannot build the executable 'getdata' because the component is marked
as disabled in the .cabal file.
```