### PR TITLE
Use toList and fmap instead of foldMap

### DIFF
--- a/demo/outorg-edit-Tutorial.html
+++ b/demo/outorg-edit-Tutorial.html
@@ -476,7 +476,7 @@ We can consider a single column.
 </p>
 
 <pre class="example">
-λ&gt; take 6 $ F.foldMap ((:[]) . view occupation) ms
+λ&gt; take 6 $ F.toList $ (view occupation) <$> ms
 ["technician","other","writer","technician","other","executive"]
 </pre>
 


### PR DESCRIPTION
This should be easier to understand, in my opinion.

I think you made this using Emacs, so if it's more convenient for you to re-run the script from Emacs rather than merge this pull request, I'm fine with that.

Maybe you could also add an example of how to pick several fields here? I assume that the best way to do this is by `(,) <$> view field1 <*> view field2` or `liftA2 (view field1) (view field2)`, but if there's a better way that would be great too!