### PR TITLE
match more doubles, fixes #53

### DIFF
--- a/Frames.cabal
+++ b/Frames.cabal
@@ -1,5 +1,5 @@
 name:                Frames
-version:             0.1.6
+version:             0.1.7
 synopsis:            Data frames For working with tabular data files
 description:         User-friendly, type safe, runtime efficient tooling for
                      working with tabular data deserialized from

--- a/src/Frames/ColumnTypeable.hs
+++ b/src/Frames/ColumnTypeable.hs
@@ -38,6 +38,8 @@ instance Parseable Bool where
 instance Parseable Int where
 instance Parseable Float where
 instance Parseable Double where
+  -- Some CSV's export Doubles in a format like '1,000.00', filtering out commas lets us parse those sucessfully
+  parse = fmap Definitely . fromText . T.filter (/= ',')
 instance Parseable T.Text where
 
 -- | This class relates a universe of possible column types to Haskell


### PR DESCRIPTION
@acowley this fixes #53  and I think anyone who tries to use Frames on exported CSV's in the future might be able to avoid this issue.

```
λ> F.toList <$> loadAs
[{id :-> 1, paid :-> 1000.0, owes :-> 999.0},{id :-> 2, paid :-> 1000000.0, owes :-> 1000.0},{id :-> 3, paid :-> 100.0, owes :-> 999.0}]
```