### PR TITLE
Fuzzy date

### DIFF
--- a/Frames.cabal
+++ b/Frames.cabal
@@ -50,6 +50,7 @@ library
                        OverloadedStrings
   build-depends:       base >=4.8 && <4.10,
                        ghc-prim >=0.3 && <0.6,
+                       git-date >=0.2.2 && < 0.3,
                        pipes >= 4.1 && < 5,
                        primitive >= 0.6 && < 0.7,
                        readable >= 0.3.1,

--- a/Frames.cabal
+++ b/Frames.cabal
@@ -1,5 +1,5 @@
 name:                Frames
-version:             0.1.7
+version:             0.1.8
 synopsis:            Data frames For working with tabular data files
 description:         User-friendly, type safe, runtime efficient tooling for
                      working with tabular data deserialized from
@@ -50,13 +50,14 @@ library
                        OverloadedStrings
   build-depends:       base >=4.8 && <4.10,
                        ghc-prim >=0.3 && <0.6,
+                       pipes >= 4.1 && < 5,
                        primitive >= 0.6 && < 0.7,
-                       text >= 1.1.1.0,
+                       readable >= 0.3.1,
                        template-haskell,
+                       text >= 1.1.1.0,
+                       time >= 1.5.0.1,
                        transformers,
                        vector,
-                       readable >= 0.3.1,
-                       pipes >= 4.1 && < 5,
                        vinyl >= 0.5 && < 0.6
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Frames.hs
+++ b/src/Frames.hs
@@ -18,6 +18,7 @@ module Frames
   , module Frames.RecLens
   , module Frames.TypeLevel
   , Text
+  , ZonedTime
   ) where
 import Data.Text (Text)
 import Data.Vinyl ((<+>))
@@ -36,3 +37,4 @@ import Frames.Rec (Record, RecordColumns, (&:), recUncons, recMaybe, showFields)
 import Frames.RecF
 import Frames.RecLens
 import Frames.TypeLevel
+import Data.Time

--- a/src/Frames/ColumnTypeable.hs
+++ b/src/Frames/ColumnTypeable.hs
@@ -1,11 +1,15 @@
 {-# LANGUAGE BangPatterns, DefaultSignatures, LambdaCase #-}
 module Frames.ColumnTypeable where
-import Control.Monad (MonadPlus)
+import Control.Monad (MonadPlus, mzero)
+import Control.Monad.Trans.Class
+import Control.Monad.IO.Class
 import Data.Readable (Readable(fromText))
 import qualified Data.Text as T
 import Language.Haskell.TH
 import Data.Time
 import Data.Time (ZonedTime(..))
+import Data.Time.Git
+import Control.Applicative
 
 data Parsed a = Possibly a | Definitely a deriving (Eq, Ord, Show)
 
@@ -45,10 +49,17 @@ instance Parseable Double where
 instance Parseable T.Text where
 instance Parseable ZonedTime where
   parse txt = do
-    fmap Definitely (parseTimeM True defaultTimeLocale "%F %T" (T.unpack txt ))
-    -- case (parseTimeM True defaultTimeLocale "%F %T" (T.unpack txt ):: Maybe ZonedTime) of
-    --   Just zt -> pure $ Definitely zt
-    --   Nothing -> error "Hm. not sure what to do here"
+    tz <- getCurrentTimeZone
+    let ts = (approxidate (T.unpack txt) :: Maybe Integer)
+    let mUtcTime = posixToUTC <$> ts :: Maybe UTCTime
+    let mZonedTime = utcToZonedTime tz <$> mUtcTime :: Maybe ZonedTime
+    let mZonedTime' = fmap Definitely mZonedTime :: Maybe (Parsed ZonedTime)
+    maybe mzero (return ) mZonedTime'
+    -- maybe mzero return mZonedTime
+    -- pure  $ Definitely mZonedTime
+
+    -- undefined
+
 
 -- | This class relates a universe of possible column types to Haskell
 -- types, and provides a mechanism to infer which type best represents

--- a/src/Frames/ColumnTypeable.hs
+++ b/src/Frames/ColumnTypeable.hs
@@ -4,6 +4,8 @@ import Control.Monad (MonadPlus)
 import Data.Readable (Readable(fromText))
 import qualified Data.Text as T
 import Language.Haskell.TH
+import Data.Time
+import Data.Time (ZonedTime(..))
 
 data Parsed a = Possibly a | Definitely a deriving (Eq, Ord, Show)
 
@@ -41,6 +43,12 @@ instance Parseable Double where
   -- Some CSV's export Doubles in a format like '1,000.00', filtering out commas lets us parse those sucessfully
   parse = fmap Definitely . fromText . T.filter (/= ',')
 instance Parseable T.Text where
+instance Parseable ZonedTime where
+  parse txt = do
+    fmap Definitely (parseTimeM True defaultTimeLocale "%F %T" (T.unpack txt ))
+    -- case (parseTimeM True defaultTimeLocale "%F %T" (T.unpack txt ):: Maybe ZonedTime) of
+    --   Just zt -> pure $ Definitely zt
+    --   Nothing -> error "Hm. not sure what to do here"
 
 -- | This class relates a universe of possible column types to Haskell
 -- types, and provides a mechanism to infer which type best represents

--- a/src/Frames/ColumnUniverse.hs
+++ b/src/Frames/ColumnUniverse.hs
@@ -34,6 +34,7 @@ import Frames.RecF (reifyDict)
 import Frames.TypeLevel (LAll)
 import Data.Typeable (TypeRep)
 import Data.Maybe (fromMaybe)
+import Data.Time
 
 -- * TypeRep Helpers
 
@@ -103,10 +104,12 @@ lubTypeReps (Definitely trX) (Definitely trY)
   | trX == trDbl && trY == trInt = Just GT
   | trX == trBool && trY == trInt = Just LT
   | trX == trInt && trY == trBool = Just GT
+  | trX == trZoneTime && trY == trZoneTime = Just GT
   | otherwise = Nothing
   where trInt = typeRep (Proxy :: Proxy Int)
         trDbl = typeRep (Proxy :: Proxy Double)
         trBool = typeRep (Proxy :: Proxy Bool)
+        trZoneTime = typeRep (Proxy :: Proxy ZonedTime)
 
 instance (T.Text ∈ ts) => Monoid (CoRec ColInfo ts) where
   mempty = Col (ColInfo ([t|T.Text|], Possibly mkTyped) :: ColInfo T.Text)
@@ -146,7 +149,7 @@ instance (LAll Parseable ts, LAll Typeable ts, FoldRec ts ts,
 -- * Common Columns
 
 -- | Common column types
-type CommonColumns = [Bool, Int, Double, T.Text]
+type CommonColumns = [ZonedTime, Bool, Int, Double, T.Text]
 
 -- | Define a set of variants that captures all possible column types.
 type ColumnUniverse = CoRec ColInfo

--- a/src/Frames/InCore.hs
+++ b/src/Frames/InCore.hs
@@ -24,6 +24,7 @@ import Frames.Col
 import Frames.Frame
 import Frames.Rec
 import Frames.RecF
+import Data.Time
 #if __GLASGOW_HASKELL__ < 800
 import GHC.Prim (RealWorld)
 #endif
@@ -38,6 +39,7 @@ type instance VectorFor Float = VU.Vector
 type instance VectorFor Double = VU.Vector
 type instance VectorFor String = VB.Vector
 type instance VectorFor Text = VB.Vector
+type instance VectorFor ZonedTime = VB.Vector
 
 -- | The mutable version of 'VectorFor' a particular type.
 type VectorMFor a = VG.Mutable (VectorFor a)


### PR DESCRIPTION
I tried adding some fuzzy date parsing that has sane defaulting by using [a binding](http://hackage.haskell.org/package/git-date) which wraps the git date functionality.

In order to do this I need to get the users current time zone. After adding some MonadIO instances I got stuck on this type error:

```
src/Frames/ColumnUniverse.hs:62:19: Could not deduce (Control.Monad.IO.Class.MonadIO Maybe) …
      arising from a use of ‘parse’
    from the context (Parseable a)
      bound by the type signature for
                 inferParseable :: Parseable a =>
                                   T.Text -> (:.) Maybe (Parsed :. Proxy) a
      at /home/cody/source/Frames/src/Frames/ColumnUniverse.hs:(58,19)-(59,58)
    In the second argument of ‘(.)’, namely
      ‘(parse :: T.Text -> Maybe (Parsed a))’
    In the second argument of ‘(.)’, namely
      ‘fmap (Compose . fmap (const Proxy))
       . (parse :: T.Text -> Maybe (Parsed a))’
    In the expression:
      Compose
      . fmap (Compose . fmap (const Proxy))
        . (parse :: T.Text -> Maybe (Parsed a))
Compilation failed.
```

Soooooo... I'd have to define a MonadIO instance for `Maybe (Parsed :. Proxy) a`?

I'll also need to get the users current time zone for later iterations of #57 whether or not it includes this fuzzy date binding or not.
