### PR TITLE
Write records to csv

### DIFF
--- a/Frames.cabal
+++ b/Frames.cabal
@@ -59,6 +59,7 @@ library
                        vector,
                        readable >= 0.3.1,
                        pipes >= 4.1 && < 5,
+                       pipes-text >= 0.0.2.0 && < 0.0.3.0,
                        vinyl >= 0.5 && < 0.6,
                        text-show >= 3.4 && < 4
   hs-source-dirs:      src

--- a/Frames.cabal
+++ b/Frames.cabal
@@ -59,7 +59,8 @@ library
                        vector,
                        readable >= 0.3.1,
                        pipes >= 4.1 && < 5,
-                       vinyl >= 0.5 && < 0.6
+                       vinyl >= 0.5 && < 0.6,
+                       text-show >= 3.4 && < 4
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/src/Frames/Rec.hs
+++ b/src/Frames/Rec.hs
@@ -21,6 +21,8 @@ import Data.Vinyl.TypeLevel (RecAll)
 import Data.Vinyl.Functor (Identity(..), Const(..), Compose(..), (:.))
 import Frames.Col
 import Frames.RecF
+import Data.Text (Text)
+import TextShow
 
 -- | A record with unadorned values. This is @Vinyl@'s 'Rec'
 -- 'Identity'. We give this type a name as it is used pervasively for
@@ -54,3 +56,16 @@ showFields = recordToList . rmap aux . reifyConstraint p . toVinyl
         aux :: (Dict Show :. Identity) a -> Const String a
         aux (Compose (Dict x)) = Const (show x)
 {-# INLINABLE showFields #-}
+
+-- TODO Possibly submit this upstream to Vinyl since it's for Data.Vinyl.Functor.Identity
+instance TextShow a => TextShow (Identity a) where
+  showt (Identity x) = showt x
+
+-- | Show each field of a 'Record' /without/ its column name.
+showFieldsText :: (RecAll Identity (UnColumn ts) TextShow, AsVinyl ts)
+           => Record ts -> [Text]
+showFieldsText = recordToList . rmap aux . reifyConstraint p . toVinyl
+  where p = Proxy :: Proxy TextShow
+        aux :: (Dict TextShow :. Identity) a -> Const Text a
+        aux (Compose (Dict x)) = Const (showt x)
+{-# INLINABLE showFieldsText #-}


### PR DESCRIPTION
- [x] Figure out how to mimic bases' `show` and ignore the `Identity { getIdentity = ... }` portion
- [x] create showFieldsText function
- [x] Figure out how to get Col values out of record
- [x] Figure out how to create a `showColText` function
- [x] figure out how to regenerate or keep original column header name
- [x] create pipe to stream rows to csv
- [x] create helper function that takes a record Producer, applies showFieldsText, then writes to csv line by line
- [ ] See if I can use UnColumns on rows and make writeCSV only take one row producer

How should regenerating the column name be handled? I'd prefer that the column name transformation be isomorphic, but I think that would require holding onto the column names somehow.

For now this just doesn't write a header.