### PR TITLE
remove unneeded and restrictive Functor g constraint from rlens'

### DIFF
--- a/src/Frames/RecLens.hs
+++ b/src/Frames/RecLens.hs
@@ -16,7 +16,7 @@ import Data.Vinyl.TypeLevel
 import Frames.Col ((:->)(..))
 import Frames.Rec (Record)
 
-rlens' :: (i ~ RIndex r rs, V.RElem r rs i, Functor f, Functor g)
+rlens' :: (i ~ RIndex r rs, V.RElem r rs i, Functor f)
        => sing r
        -> (g r -> f (g r))
        -> V.Rec g rs


### PR DESCRIPTION
the workaround is pretty easy - just use `rlens` from `Data.Vinyl.Lens`