### PR TITLE
test stub for latin1-encoded data

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,9 @@
+resolver: lts-9.13
+packages:
+- '.'
+extra-deps:
+- vinyl-0.6.0
+flags:
+  Frames:
+    demos: false
+extra-package-dbs: []

--- a/test/data/latinManagers.csv
+++ b/test/data/latinManagers.csv
@@ -1,0 +1,3 @@
+id,manager,age,pay
+1,João,53,"80,000"
+2,Esperança,44,"80,000"

--- a/test/latinTest.hs
+++ b/test/latinTest.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE ConstraintKinds   #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TypeOperators     #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module PipesSafe where
+
+import           Data.Vinyl    (Rec)
+import           Frames        ((:->), MonadSafe, Text, runSafeEffect)
+import           Frames.CSV    (declareColumn, pipeTableMaybe, readFileLatin1Ln)
+import           Frames.Rec
+import           Pipes         (Producer, (>->))
+import qualified Pipes.Prelude as P
+
+declareColumn "mId" ''Int
+declareColumn "manager" '' Text
+declareColumn "age" ''Int
+declareColumn "pay" ''Int
+
+type ManColumns = '["id" :-> Int, "manager" :-> Text, "age" :-> Int, "pay" :-> Text]
+type ManRow = Record ManColumns
+type ManMaybe = Rec Maybe ManColumns
+
+manStreamM :: MonadSafe m => Producer ManMaybe m ()
+manStreamM = readFileLatin1Ln "test/data/latinManagers.csv" >-> pipeTableMaybe
+
+printManagers :: IO ()
+printManagers =
+  runSafeEffect $ manStreamM >-> P.map recMaybe >-> P.concat >-> P.print


### PR DESCRIPTION
This is pretty much my use case without specialized types. I have no idea where to go from here to test the results of the stream from within IO. Should be a test case for #96.