### PR TITLE
Switch joins to use Hashable for Text

### DIFF
--- a/Frames.cabal
+++ b/Frames.cabal
@@ -67,7 +67,8 @@ library
                        pipes-text >= 0.0.2.5 && < 0.1,
                        vinyl >= 0.7 && < 0.8,
                        discrimination,
-                       contravariant
+                       contravariant,
+                       hashable
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -171,12 +172,11 @@ executable missing
   default-language: Haskell2010
 
 -- Demo the joins feature
-executable joins
-  if !flag(demos)
-    buildable: False
-  main-is:          JoinsDemo.hs
-  hs-source-dirs:   demo
-  build-depends:    base, Frames
+benchmark joins
+  type:             exitcode-stdio-1.0
+  main-is:          JoinsBench.hs
+  hs-source-dirs:   benchmarks
+  build-depends:    base, Frames, criterion
   ghc-options:      -O2 
   default-language: Haskell2010
 

--- a/benchmarks/JoinsBench.hs
+++ b/benchmarks/JoinsBench.hs
@@ -6,6 +6,7 @@
 
 import Frames
 import Frames.Joins
+import Criterion.Main
 
 tableTypes "LCols" "data/left1.csv"
 tableTypes "RCols" "data/right1.csv"
@@ -25,13 +26,14 @@ main = do
   lf <- lfi
   rf <- rfi
   smf <- smfi
-  print $ length $ innerJoin @'[PolicyID] lf rf
-  print $ length $ innerJoin @'[PolicyID] lf smf
-  print $ length $ innerJoin @'[PolicyID,County] lf smf
-  print $ length $ outerJoin @'[PolicyID,County] lf smf
-  print $ length $ leftJoin  @'[PolicyID,County] lf smf
-  print $ length $ rightJoin @'[PolicyID,County] lf smf                             
-
+  defaultMain [
+    bench "inner1a"   $ whnf  (innerJoin @'[PolicyID] lf) rf
+    , bench "inner1b" $ whnf  (innerJoin @'[County] lf) smf
+    , bench "inner2"  $ whnf  (innerJoin @'[PolicyID,County] lf) smf
+    , bench "outer2"  $ whnf  (outerJoin @'[PolicyID,County] lf) smf
+    , bench "left2"   $ whnf  (leftJoin  @'[PolicyID,County] lf) smf
+    , bench "left2"   $ whnf  (rightJoin @'[PolicyID,County] lf) smf                             
+    ]
     
 
   


### PR DESCRIPTION
Substantial speed up for most reasonable use cases.
A better default until discrimination gets the speed up
discussed in #105

Also converts joins demo to a proper benchmark