### PR TITLE
Prevent bad build plans on GHC 7.10

### DIFF
--- a/Frames.cabal
+++ b/Frames.cabal
@@ -52,7 +52,7 @@ library
   other-extensions:    DataKinds, GADTs, KindSignatures, TypeFamilies,
                        TypeOperators, ConstraintKinds, StandaloneDeriving,
                        UndecidableInstances, ScopedTypeVariables,
-                       OverloadedStrings
+                       OverloadedStrings, TypeApplications
   build-depends:       base >=4.8 && <4.12,
                        ghc-prim >=0.3 && <0.6,
                        primitive >= 0.6 && < 0.7,


### PR DESCRIPTION
Tell cabal we're using TypeApplications so it knows not to try to
build on GHC versions that don't support that extension.