### PR TITLE
Specify version for Vinyl

### DIFF
--- a/demo/framestack/stack.yaml
+++ b/demo/framestack/stack.yaml
@@ -6,7 +6,6 @@ packages:
 extra-deps:
 - git: https://github.com/acowley/Frames.git
   commit: 191de8964dfc71119c62087ae81d362726114677
-  subdirs:
-    - Vinyl
-    - .
+- git: https://github.com/VinylRecords/Vinyl.git
+  commit: e16ba6461bb12aa942bfd2cd41604be76dfc9eb7
 


### PR DESCRIPTION
This fixes broken build using stack v1.9.x
Note: broken at the moment with stack 2.1.1, probably due to a stack bug in the
way stack uses tar.