### PR TITLE
Create TypeInfo, add type inference unit tests

### DIFF
--- a/Frames.cabal
+++ b/Frames.cabal
@@ -230,7 +230,7 @@ test-suite spec
                        Categorical Chunks
   build-depends:       base, text, hspec, Frames, template-haskell,
                        temporary, directory, htoml, regex-applicative, pretty,
-                       unordered-containers, pipes, HUnit, vinyl,
+                       unordered-containers, pipes, HUnit, vector, vinyl,
                        foldl >= 1.3 && < 1.5,
                        attoparsec, lens
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall

--- a/src/Frames/Categorical.hs
+++ b/src/Frames/Categorical.hs
@@ -129,4 +129,5 @@ instance KnownNat n => Parseable (Categorical n) where
           maxVariants :: Int
           maxVariants = fromIntegral (toInteger (natVal' (proxy# :: Proxy# n)))
   representableAsType (S.toList . categories . parsedValue -> cats) =
-    Const (Left (\n -> declareCategorical n (Just n) (map T.unpack cats)))
+    Const . TypeGenerator $
+      \n -> declareCategorical n (Just n) (map T.unpack cats)


### PR DESCRIPTION
I was trying to figure out how Frames' type inference works. I have to move on to something else for now, but some of what I've done may be useful so I'm opening this pull request to contribute it.

One of my changes was to replace `Either (String -> Q [Dec]) Type` with a new data type: `TypeInfo`.

The other change is to add some type inference unit tests. They all pass, although the behaviour they expect is not what I would like it to be. I have ideas for a more general type inference mechanism, but no time to implement it at this stage.