### PR TITLE
TH fixes for ghc-8.8+ (TySynInstD and TySynEqn have different syntax)…

### DIFF
--- a/src/Frames/CSV.hs
+++ b/src/Frames/CSV.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, FlexibleInstances, GADTs,
+{-# LANGUAGE CPP, DataKinds, FlexibleContexts, FlexibleInstances, GADTs,
              LambdaCase, OverloadedStrings, RankNTypes,
              ScopedTypeVariables, TemplateHaskell, TypeApplications,
              TypeOperators #-}
@@ -13,7 +13,9 @@ import qualified Data.ByteString.Char8 as B8
 import qualified Data.Foldable as F
 import Data.List (intercalate)
 import Data.Maybe (isNothing, fromMaybe)
+#if __GLASGOW_HASKELL__ < 808
 import Data.Monoid ((<>))
+#endif
 import Data.Proxy
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T

--- a/src/Frames/Categorical.hs
+++ b/src/Frames/Categorical.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, KindSignatures, MagicHash,
+{-# LANGUAGE CPP, DataKinds, KindSignatures, MagicHash,
              ScopedTypeVariables, TemplateHaskell, TypeFamilies,
              ViewPatterns #-}
 -- | Support for representing so-called categorical variables: a
@@ -108,7 +108,11 @@ declareCategorical (cap -> name) (fmap cap -> prefix) variants =
           InstanceD Nothing [] (AppT (ConT ''ShowCSV) (ConT nameName))
                     [FunD 'showCSV (onVariants showCSVClause)]
         iVectorFor =
+#if __GLASGOW_HASKELL__ >= 808          
+          TySynInstD (TySynEqn Nothing (AppT (ConT ''VectorFor) (ConT nameName)) (ConT ''VU.Vector))
+#else
           TySynInstD ''VectorFor (TySynEqn [ConT nameName] (ConT ''VU.Vector))
+#endif
         iNFData =
           let argName = mkName "x"
           in InstanceD Nothing [] (AppT (ConT ''NFData) (ConT nameName))

--- a/src/Frames/ColumnUniverse.hs
+++ b/src/Frames/ColumnUniverse.hs
@@ -10,7 +10,9 @@ module Frames.ColumnUniverse (
   CommonColumns, CommonColumnsCat, parsedTypeRep
 ) where
 import Data.Maybe (fromMaybe)
+#if __GLASGOW_HASKELL__ < 808
 import Data.Semigroup (Semigroup((<>)))
+#endif
 import qualified Data.Text as T
 import Data.Vinyl
 import Data.Vinyl.CoRec

--- a/test/Categorical.hs
+++ b/test/Categorical.hs
@@ -1,14 +1,19 @@
 {-# LANGUAGE DataKinds, FlexibleContexts, MultiParamTypeClasses,
-             OverloadedLabels, OverloadedStrings, TemplateHaskell,
-             TypeFamilies, TypeOperators #-}
+             OverloadedLabels, OverloadedStrings, TemplateHaskell, 
+             TypeApplications, TypeFamilies, TypeOperators #-}
 module Categorical where
-import Data.Vinyl.Derived
-import Data.Vinyl.XRec (toHKD)
-import Frames
-import Frames.Categorical (declareCategorical)
-import Frames.TH (rowGenCat, RowGen(..), declarePrefixedColumn)
-import Pipes (Producer, (>->))
-import qualified Pipes.Prelude as P
+import           Data.Vinyl.Derived
+import           Data.Vinyl.XRec                ( toHKD )
+import           Frames
+import           Frames.Categorical             ( declareCategorical )
+import           Frames.TH                      ( rowGenCat
+                                                , RowGen(..)
+                                                , declarePrefixedColumn
+                                                )
+import           Pipes                          ( Producer
+                                                , (>->)
+                                                )
+import qualified Pipes.Prelude                 as P
 
 -- * Automatically inferred categorical data types
 
@@ -19,17 +24,19 @@ tableTypes' (rowGenCat "test/data/catLarge.csv") { rowTypeName = "Large", tableP
 -- no more than 8 variants. In our small data file, five distinct
 -- months appear, so a data type is generated and used.
 fifthMonthSmall :: IO (Maybe SmallMonth)
-fifthMonthSmall = fmap (fmap (rvalf #month)) . runSafeEffect . P.head
-                $ load >-> P.drop 4
-  where load :: MonadSafe m => Producer Small m ()
-        load = readTableOpt smallParser "test/data/catSmall.csv"
+fifthMonthSmall =
+  fmap (fmap (rvalf #month)) . runSafeEffect . P.head $ load >-> P.drop 4
+ where
+  load :: MonadSafe m => Producer Small m ()
+  load = readTableOpt smallParser "test/data/catSmall.csv"
 
 -- When every month appears, Frames leaves that column's type as 'Text'.
 fifthMonthLarge :: IO (Maybe Text)
-fifthMonthLarge = fmap (fmap (rvalf #month)) . runSafeEffect . P.head
-                $ load >-> P.drop 4
-  where load :: MonadSafe m => Producer Large m ()
-        load = readTableOpt largeParser "test/data/catLarge.csv"
+fifthMonthLarge =
+  fmap (fmap (rvalf #month)) . runSafeEffect . P.head $ load >-> P.drop 4
+ where
+  load :: MonadSafe m => Producer Large m ()
+  load = readTableOpt largeParser "test/data/catLarge.csv"
 
 -- * Custom categorical type
 
@@ -51,7 +58,8 @@ type MyRow = Record '[MyId, MyMonth]
 -- parses. We use 'toHKD' to cut through the noise of the @(Maybe
 -- :. ElField)@ interpretation we parsed into.
 fifthMonthCustom :: IO (Maybe MyMonthData)
-fifthMonthCustom = fmap (>>= toHKD . rgetf #month) . runSafeEffect . P.head
-                 $ load >-> P.drop 4
-  where load :: MonadSafe m => Producer (ColFun Maybe MyRow) m ()
-        load = readTableMaybe "test/data/catSmall.csv"
+fifthMonthCustom =
+  fmap (>>= toHKD . rgetf #month) . runSafeEffect . P.head $ load >-> P.drop 4
+ where
+  load :: MonadSafe m => Producer (ColFun Maybe MyRow) m ()
+  load = readTableMaybe "test/data/catSmall.csv"

--- a/test/Issue114.hs
+++ b/test/Issue114.hs
@@ -5,23 +5,27 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE TypeApplications  #-}
 module Issue114 where
 import           Frames
-import qualified Control.Foldl as Foldl
+import qualified Control.Foldl                 as Foldl
 import           Control.Lens
-import           Pipes.Prelude (fold)
+import           Pipes.Prelude                  ( fold )
 import           Pipes
-import qualified Pipes.Prelude as P
-import qualified Pipes.Core as PC
+import qualified Pipes.Prelude                 as P
+import qualified Pipes.Core                    as PC
 
-import qualified Data.Vinyl as V
-import           Data.Vinyl (Rec(..))
+import qualified Data.Vinyl                    as V
+import           Data.Vinyl                     ( Rec(..) )
 
-import qualified Data.Text as T
+import qualified Data.Text                     as T
 import           Data.Attoparsec.Text
 import           Control.Applicative
 
-import Frames.TH (tableTypesText', rowGen, RowGen(..))
+import           Frames.TH                      ( tableTypesText'
+                                                , rowGen
+                                                , RowGen(..)
+                                                )
 
 tableTypesText' (rowGen "test/data/issue114.csv") { rowTypeName = "ProductionData" }
 
@@ -29,13 +33,12 @@ declareColumn "oil_vol_double" ''Double
 
 getOilVol :: ProductionData -> Record '[OilVolDouble]
 getOilVol x = V.Field (f (parseOnly parseDouble (x ^. oilVol))) :& RNil
-  where
-    f (Left _)  = 0.0 / 0.0
-    f (Right y) = y
+ where
+  f (Left  _) = 0.0 / 0.0
+  f (Right y) = y
 
 readOilVol :: MonadSafe m => Producer (Record '[OilVolDouble]) m ()
-readOilVol = (readTable "test/data/issue114.csv") >->
-             (P.map getOilVol)
+readOilVol = (readTable "test/data/issue114.csv") >-> (P.map getOilVol)
 
 oilVolLength :: Foldl.Fold (Record '[OilVolDouble]) Int
 oilVolLength = Foldl.length
@@ -48,16 +51,16 @@ oilVolTotalAndLength = (,) <$> totalOilVol <*> oilVolLength
 
 parseDouble :: Parser Double
 parseDouble =
-  do d <- double
-     return d
-  <|>
-  do _ <- string ""
-     return 0.0
+  do
+      d <- double
+      return d
+    <|> do
+          _ <- string ""
+          return 0.0
 
 test :: IO ()
 test = do
-  (t, l) <- runSafeT $
-            Foldl.purely fold oilVolTotalAndLength readOilVol
+  (t, l) <- runSafeT $ Foldl.purely fold oilVolTotalAndLength readOilVol
   putStrLn $ show l ++ " records totalling " ++ show t
 
 loadTable :: MonadSafe m => PC.Producer ProductionData m ()

--- a/test/NoHeader.hs
+++ b/test/NoHeader.hs
@@ -1,11 +1,15 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, OverloadedLabels, TemplateHaskell   #-}
+{-# LANGUAGE DataKinds, FlexibleContexts, OverloadedLabels, TemplateHaskell, TypeApplications   #-}
 module NoHeader where
-import Control.Arrow ((&&&))
-import Data.Vinyl.Derived
-import Frames
-import Frames.TH (rowGen, RowGen(..))
-import Pipes (Producer, (>->))
-import qualified Pipes.Prelude as P
+import           Control.Arrow                  ( (&&&) )
+import           Data.Vinyl.Derived
+import           Frames
+import           Frames.TH                      ( rowGen
+                                                , RowGen(..)
+                                                )
+import           Pipes                          ( Producer
+                                                , (>->)
+                                                )
+import qualified Pipes.Prelude                 as P
 
 tableTypes' (rowGen "test/data/prestigeNoHeader.csv")
             { rowTypeName = "Row"
@@ -22,7 +26,8 @@ loadData = readTableOpt rowParser "test/data/prestigeNoHeader.csv"
 
 -- | Extract the @Job@ and @Schooling@ columns of the indicated row.
 getJobAndSchooling :: Int -> IO (Maybe (Text, Double))
-getJobAndSchooling n = fmap (fmap aux) . runSafeEffect . P.head
-                     $ loadData >-> P.drop (max n 0)
-  where aux :: Row -> (Text, Double)
-        aux = rvalf #job &&& rvalf #schooling
+getJobAndSchooling n =
+  fmap (fmap aux) . runSafeEffect . P.head $ loadData >-> P.drop (max n 0)
+ where
+  aux :: Row -> (Text, Double)
+  aux = rvalf #job &&& rvalf #schooling

--- a/test/Overlap.hs
+++ b/test/Overlap.hs
@@ -1,6 +1,9 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, TemplateHaskell #-}
-module Main (main) where
-import Frames
+{-# LANGUAGE DataKinds, FlexibleContexts, TemplateHaskell, TypeApplications #-}
+module Main
+  ( main
+  )
+where
+import           Frames
 
 -- These data files have overlapping column definitions. Frames should
 -- not try to re-define an existing identifier.

--- a/test/UncurryFold.hs
+++ b/test/UncurryFold.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, QuasiQuotes, TemplateHaskell #-}
+{-# LANGUAGE DataKinds, FlexibleContexts, QuasiQuotes, TemplateHaskell, TypeApplications #-}
 module UncurryFold where
-import qualified Control.Foldl as L
-import Data.Vinyl (rcast)
-import Data.Vinyl.Curry (runcurryX)
-import Frames
+import qualified Control.Foldl                 as L
+import           Data.Vinyl                     ( rcast )
+import           Data.Vinyl.Curry               ( runcurryX )
+import           Frames
 
 -- Data set from http://vincentarelbundock.github.io/Rdatasets/datasets.html
 tableTypes "Row" "test/data/prestige.csv"

--- a/test/UncurryFoldNoHeader.hs
+++ b/test/UncurryFoldNoHeader.hs
@@ -1,10 +1,12 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, QuasiQuotes, TemplateHaskell #-}
+{-# LANGUAGE DataKinds, FlexibleContexts, QuasiQuotes, TemplateHaskell, TypeApplications #-}
 module UncurryFoldNoHeader where
-import qualified Control.Foldl as L
-import Data.Vinyl (rcast)
-import Data.Vinyl.Curry (runcurryX)
-import Frames
-import Frames.TH (rowGen, RowGen(..))
+import qualified Control.Foldl                 as L
+import           Data.Vinyl                     ( rcast )
+import           Data.Vinyl.Curry               ( runcurryX )
+import           Frames
+import           Frames.TH                      ( rowGen
+                                                , RowGen(..)
+                                                )
 
 -- Data set from http://vincentarelbundock.github.io/Rdatasets/datasets.html
 tableTypes' (rowGen "test/data/prestigeNoHeader.csv")


### PR DESCRIPTION
- Fixed the TH.  Please double check!!
- Added ```TypeApplications``` to a few tests where necessary
- Wrapped the TH change and some imports of ```(<>)``` in CPP to make all compile, and without warnings, on ghc pre and post 8.8.