### PR TITLE
Add sanitize to categorical constructor name

### DIFF
--- a/Frames.cabal
+++ b/Frames.cabal
@@ -58,6 +58,7 @@ library
                        Frames.TypeLevel
                        Frames.Joins
                        Frames.ExtraInstances
+                       Frames.Utils
   other-extensions:    DataKinds, GADTs, KindSignatures, TypeFamilies,
                        TypeOperators, ConstraintKinds, StandaloneDeriving,
                        UndecidableInstances, ScopedTypeVariables,
@@ -227,7 +228,7 @@ test-suite spec
   main-is:             Spec.hs
   other-modules:       DataCSV PrettyTH Temp LatinTest Issue114 NoHeader
                        UncurryFold UncurryFoldNoHeader UncurryFoldPartialData
-                       Categorical Chunks
+                       Categorical Chunks Issue145
   build-depends:       base, text, hspec, Frames, template-haskell,
                        temporary, directory, htoml, regex-applicative, pretty,
                        unordered-containers, pipes, HUnit, vinyl,

--- a/src/Frames/Categorical.hs
+++ b/src/Frames/Categorical.hs
@@ -24,6 +24,7 @@ import qualified Data.Vector.Unboxed as VU
 import Frames.ColumnTypeable
 import Frames.InCore (VectorFor)
 import Frames.ShowCSV
+import Frames.Utils
 import GHC.Exts (Proxy#, proxy#)
 import GHC.TypeNats
 import Language.Haskell.TH
@@ -67,11 +68,11 @@ declareCategorical (cap -> name) (fmap cap -> prefix) variants =
   ([ dataDecl, iIsString, iReadable, iParseable
    , iShowCSV, iVectorFor, iNFData ] ++)
   <$> unboxDecls name (length variants)
-  where variantCons = map (mkName . maybe id (++) prefix . cap) variants
+  where variantCons = map (mkName . T.unpack . sanitizeTypeName . T.pack . maybe id (++) prefix . cap) variants
         onVariants :: (String -> Name -> a) -> [a]
         onVariants f =
           getZipList (f <$> ZipList variants <*> ZipList variantCons)
-        nameName = mkName name
+        nameName = mkName . T.unpack . sanitizeTypeName . T.pack $ name
         fromStringClause variant variantCon =
           Clause [LitP (StringL variant)] (NormalB (ConE variantCon)) []
         showCSVClause variant variantCon =

--- a/src/Frames/Utils.hs
+++ b/src/Frames/Utils.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE CPP, OverloadedStrings #-}
+module Frames.Utils (capitalize1, sanitizeTypeName) where
+
+import Control.Arrow (first)
+import Data.Char (isAlpha, isAlphaNum, toUpper)
+#if __GLASGOW_HASKELL__ < 804
+import Data.Semigroup ((<>))
+#endif
+import qualified Data.Text as T
+
+-- | Capitalize the first letter of a 'T.Text'.
+capitalize1 :: T.Text -> T.Text
+capitalize1 = foldMap (onHead toUpper) . T.split (not . isAlphaNum)
+  where onHead f = maybe mempty (uncurry T.cons . first f) . T.uncons
+
+-- | Massage a column name from a CSV file into a valid Haskell type
+-- identifier.
+sanitizeTypeName :: T.Text -> T.Text
+sanitizeTypeName = unreserved . fixupStart
+                 . T.concat . T.split (not . valid) . capitalize1
+  where valid c = isAlphaNum c || c == '\'' || c == '_'
+        unreserved t
+          | t `elem` ["Type", "Class"] = "Col" <> t
+          | otherwise = t
+        fixupStart t = case T.uncons t of
+                         Nothing -> "Col"
+                         Just (c,_) | isAlpha c -> t
+                                    | otherwise -> "Col" <> t

--- a/test/Issue145.hs
+++ b/test/Issue145.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Issue145 where
+
+import Frames.TH (RowGen (..), rowGenCat, tableTypes')
+
+tableTypes' (rowGenCat "test/data/issue145.csv") { rowTypeName = "Row", tablePrefix = "C" }

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -26,6 +26,7 @@ import Test.HUnit.Lang (assertFailure)
 
 import qualified LatinTest as Latin
 import qualified Issue114 as Issue114
+import qualified Issue145
 import qualified NoHeader
 import qualified Categorical
 
@@ -203,6 +204,10 @@ main = do
          mCustom <- H.runIO Categorical.fifthMonthCustom
          it "Can parse into manually-specified categorical variables" $
            mCustom `shouldBe` Just Categorical.MyMay
+         it "Can generate categorical types with space" $
+           enumFrom (minBound :: Issue145.RowCategoryName)
+             `shouldBe` [ Issue145.RowCategoryNameBarCategory
+                        , Issue145.RowCategoryNameFooCategory]
        describe "Detects parse failures" $ do
          caught <- H.runIO $
            (runSafeT $ do

--- a/test/data/issue145.csv
+++ b/test/data/issue145.csv
@@ -1,0 +1,3 @@
+id,category name
+1,foo category
+2,bar category


### PR DESCRIPTION
This addresses issue #145.

Before this fix
```
test/Issue145.hs:11:1: error:
    Illegal data constructor name: ‘RowCategoryNameBar category’
    When splicing a TH declaration:
      data RowCategoryName
    = RowCategoryNameBar category | RowCategoryNameFoo category
    deriving (GHC.Classes.Eq,
              GHC.Enum.Enum,
              GHC.Enum.Bounded,
              GHC.Classes.Ord,
              GHC.Show.Show)
   |
11 | tableTypes' (rowGenCat "test/data/issue145.csv") { rowTypeName = "Row", tablePrefix = "C" }
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cabal: Failed to build test:spec from Frames-0.6.2.
```