### PR TITLE
fix(shell.nix): for global usage

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,8 @@
 , sources ? import ./nix/sources.nix
 }:
 let
-  pkgs = import sources.nixpkgs-chan {};
+  nixConfig = { allowBroken = true; };
+  pkgs = import sources.nixpkgs-chan { config = nixConfig; };
   overrideByVersion = if compiler == "ghc8101"
                       then self: super: { }
                       else self: super: { };
@@ -12,7 +13,6 @@ let
             then pkgs.haskellPackages
             else pkgs.haskell.packages.${compiler}).override {
     overrides = self: super: {
-      vinyl = pkgs.haskell.lib.dontBenchmark (super.callPackage ~/Projects/Vinyl {});
       statestack = pkgs.haskell.lib.doJailbreak super.statestack;
       svg-builder = pkgs.haskell.lib.doJailbreak super.svg-builder;
       size-based = pkgs.haskell.lib.doJailbreak super.size-based;


### PR DESCRIPTION
currently refers local paths which is not portable.

Also had to allow broken packages else it wouldn't enter nix-shell.  I like to have haskell-language-server when going through the codebase and without these changes, I can't enter the nix-shell.
